### PR TITLE
Clang scan-build

### DIFF
--- a/client/bankid.c
+++ b/client/bankid.c
@@ -242,7 +242,13 @@ BankIDError bankid_storeCertificates(const char *certs, const char *hostname) {
     
     if (!p7data) return BIDERR_InternalError;
     
-    BankIDError error = backend_storeCertificates(p7data, length, hostname);
+    TokenError storeerror = backend_storeCertificates(p7data, length, hostname);
+    BankIDError error;
+    if (storeerror) {
+        error = BIDERR_InternalError;
+    } else {
+        error = BIDERR_OK;
+    }
     
     free(p7data);
     return error;

--- a/plugin/plugin.h
+++ b/plugin/plugin.h
@@ -96,8 +96,8 @@ char *version_getVersion(Plugin *plugin);
 char *sign_getParam(Plugin *plugin, const char *name);
 bool sign_setParam(Plugin *plugin, const char *name, const char *value);
 int sign_performAction(Plugin *plugin, const char *action);
-int sign_performAction_Authenticate(Plugin *plugin);
-int sign_performAction_Sign(Plugin *plugin);
+BankIDError sign_performAction_Authenticate(Plugin *plugin);
+BankIDError sign_performAction_Sign(Plugin *plugin);
 
 void regutil_setParam(Plugin *plugin, const char *name, const char *value);
 void regutil_initRequest(Plugin *plugin, const char *type);


### PR DESCRIPTION
Körde igenom fribid i clang scan-build (http://clang-analyzer.llvm.org/), och hittade två potentiella problem.

scan-build har ytterligare två till varningar, som jag inte riktigt greppat.

```
main.c:281:13: warning: Potential leak of memory pointed to by 'input.pkcs10'
            secmem_free_page(password);
            ^~~~~~~~~~~~~~~~

npobject.c:43:12: warning: Result of 'malloc' is converted to a pointer of type 'NPObject',
 which is incompatible with sizeof operand type 'PluginObject'
    return malloc(sizeof(PluginObject));
           ^~~~~~ ~~~~~~~~~~~~~~~~~~~~
```
