### PR TITLE
Only free(origin) when we are done using it.

### DIFF
--- a/client/pkcs12.c
+++ b/client/pkcs12.c
@@ -694,7 +694,6 @@ static TokenError storeCertificates(STACK_OF(X509) *certs,
             
             char *origin = certutil_getBagAttr(bag, objOwningHost);
             bool equal = (origin && strcmp(origin, hostname) == 0);
-            free(origin);
             ASN1_OBJECT_free(objOwningHost);
             if (!equal) {
                 char *str = rasprintf("file=%s, request=%s", origin, hostname);
@@ -702,7 +701,8 @@ static TokenError storeCertificates(STACK_OF(X509) *certs,
                 hostname_mismatch = true;
                 continue;
             }
-            
+            free(origin);
+
             // Extract cert from bag
             X509 *cert = PKCS12_certbag2x509(bag);
             if (!cert) {

--- a/client/prefs.c
+++ b/client/prefs.c
@@ -40,7 +40,9 @@ void prefs_load(void) {
     PlatformConfig *cfg = platform_openConfig("fribid", "config");
     
     /* Set defaults */
+#if ENABLE_PKCS11
     prefs_pkcs11_module = DEFAULT_PKCS11_MODULE;
+#endif
     prefs_bankid_emulatedversion = NULL;
     prefs_debug_dump = false;
     


### PR DESCRIPTION
origin is used in:

char *str = rasprintf("file=%s, request=%s", origin, hostname);

Free it afterwards :).
